### PR TITLE
feat: Adding Close PR API call

### DIFF
--- a/close-pr/close-pr.go
+++ b/close-pr/close-pr.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -12,7 +13,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func PullRequestClose(token, githubrepo, githubref string) error {
+func PullRequestClose(token, githubrepo, githubref string) {
 	// get env token
 	// Connect to giithub
 	var client *github.Client
@@ -37,12 +38,13 @@ func PullRequestClose(token, githubrepo, githubref string) error {
 	githubrefS := strings.Split(githubref, "/")
 	branch := githubrefS[2]
 	bid, _ := strconv.Atoi(branch)
-	//prs, _, err := client.PullRequests.Edit(context.Background(), repoUser, repoName, bid)
-	//if err != nil {
-	//	return false, err
-	//}
-	//fmt.Println(prs)
-	//return prs, nil
+	state := "closed"
+
+	prs, _, err := client.PullRequests.Edit(context.Background(), repoUser, repoName, bid, &github.PullRequest{State: &state})
+	if err != nil {
+		log.Fatal()
+	}
+	fmt.Println(prs)
 }
 
 var (
@@ -53,8 +55,5 @@ var (
 
 func main() {
 	flag.Parse()
-	err := PullRequestClose(*token, *githubrepo, *githubref)
-	if err != nil {
-		log.Fatal(err)
-	}
+	PullRequestClose(*token, *githubrepo, *githubref)
 }

--- a/close-pr/close-pr_test.go
+++ b/close-pr/close-pr_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPullRequestClose(t *testing.T) {
+	type args struct {
+		token      string
+		githubrepo string
+		githubref  string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		wantSuccess bool
+	}{
+		{
+			name: "Successful Close PR",
+			args: args{
+				token:      os.Getenv("GITHUB_OAUTH_TOKEN"),
+				githubrepo: "jackstockley89/golangwebpage",
+				githubref:  "refs/pull/120/merge",
+			},
+			wantErr:     false,
+			wantSuccess: true,
+		},
+		{
+			name: "Fail Close PR",
+			args: args{
+				token:      os.Getenv("GITHUB_OAUTH_TOKEN"),
+				githubrepo: "%/%",
+				githubref:  "refs/pull/000/merge",
+			},
+			wantErr:     true,
+			wantSuccess: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PullRequestClose(tt.args.token, tt.args.githubrepo, tt.args.githubref)
+		})
+	}
+}


### PR DESCRIPTION
Adding a function that can close a PR when called as a github actions, this
will allow for the automation of closing unwanted PR's within the a Repo
without having to resort to manual intervention