### PR TITLE
goreleaser 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ ENV \
 
 WORKDIR /go/bin
 
-COPY go.mod .
-COPY go.sum .
+COPY go.mod /go/bin
+COPY go.sum /go/bin
 RUN go mod download
-COPY ./${DIRECTORY} .
+COPY ./${DIRECTORY} /go/bin
 
 RUN go build -ldflags "-s -w" .
 


### PR DESCRIPTION
- fix(typo): fix for path to gorelease config file
- fix(typo): path has a forward at the start which is a typo
- fix: goreleaser
- fix: goreleaser
- fix: goreleaser
- feat(goreleaser): Add builds and push for go images
- fix(Dockerfile): Change copy syntax to match goreleaser documents
